### PR TITLE
Update basic_example.ipynb

### DIFF
--- a/docs/tutorials/basic_example.ipynb
+++ b/docs/tutorials/basic_example.ipynb
@@ -88,7 +88,7 @@
     "#       settings, see `kilosort.run_kilosort.default_settings`.\n",
     "settings = {'data_dir': SAVE_PATH.parent, 'n_chan_bin': 385}\n",
     "\n",
-    "ops, st, clu, tF, Wall, similar_templates, is_ref, est_contam_rate = \\\n",
+    "ops, st, clu, tF, Wall, similar_templates, is_ref, est_contam_rate, kept_spikes = \\\n",
     "    run_kilosort(\n",
     "        settings=settings, probe_name='neuropixPhase3B1_kilosortChanMap.mat',\n",
     "        # save_preprocessed_copy=True\n",


### PR DESCRIPTION
kept_spikes is missed when run_kilosort()  is executed.